### PR TITLE
Sprint 1 Inc 1

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,3 +1,74 @@
 package main
 
-func main() {}
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/metrics"
+)
+
+const (
+	pollInterval   = time.Duration(2 * time.Second)
+	reportInterval = time.Duration(10 * time.Second)
+	endpoint       = "127.0.0.1:8080"
+)
+
+func poll(m *metrics.Metrics) {
+	ticker := time.NewTicker(pollInterval)
+	for {
+		<-ticker.C
+		m.Update()
+		fmt.Println("poll")
+	}
+}
+
+func send(client *http.Client, endpoint string) {
+	request, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBufferString(""))
+	if err != nil {
+		log.Fatal(err)
+	}
+	request.Header.Add("Content-Type", "text/plain")
+	fmt.Println("do-start")
+	response, err := client.Do(request)
+	fmt.Println("do-end")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer response.Body.Close()
+}
+
+func report(m *metrics.Metrics) {
+	ticker := time.NewTicker(reportInterval)
+	client := &http.Client{}
+	fmt.Println("report-init")
+	for {
+		<-ticker.C
+		fmt.Println("report-tick")
+		m.Mutex.Lock()
+		counters := m.Counters
+		gauges := m.Gauges
+		m.Mutex.Unlock()
+		fmt.Println("report-start")
+		for k, v := range counters {
+			send(client, fmt.Sprintf("http://%s/update/%s/%s/%d", endpoint, "counter", k, v))
+		}
+		for k, v := range gauges {
+			send(client, fmt.Sprintf("http://%s/update/%s/%s/%f", endpoint, "gauge", k, v))
+		}
+		fmt.Println("report-end")
+	}
+}
+
+func main() {
+	var wg sync.WaitGroup
+	m := metrics.NewMetrics()
+	fmt.Println("start")
+	wg.Add(2)
+	go poll(m)
+	go report(m)
+	wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/AndrewSukhobok95/yagometrics.git
+
+go 1.19

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"math/rand"
+	"runtime"
+	"sync"
+)
+
+type Metrics struct {
+	Counters map[string]int64
+	Gauges   map[string]float64
+	Mutex    sync.Mutex
+	rtm      runtime.MemStats
+}
+
+func (m *Metrics) Update() {
+	runtime.ReadMemStats(&m.rtm)
+	m.Mutex.Lock()
+	m.Counters["PollCount"] += 1
+	m.Gauges["RandomValue"] = rand.Float64()
+	m.Gauges["Alloc"] = float64(m.rtm.Alloc)
+	m.Gauges["BuckHashSys"] = float64(m.rtm.BuckHashSys)
+	m.Gauges["Frees"] = float64(m.rtm.Frees)
+	m.Gauges["GCCPUFraction"] = float64(m.rtm.GCCPUFraction)
+	m.Gauges["GCSys"] = float64(m.rtm.GCSys)
+	m.Gauges["HeapAlloc"] = float64(m.rtm.HeapAlloc)
+	m.Gauges["HeapIdle"] = float64(m.rtm.HeapIdle)
+	m.Gauges["HeapInuse"] = float64(m.rtm.HeapInuse)
+	m.Gauges["HeapObjects"] = float64(m.rtm.HeapObjects)
+	m.Gauges["HeapReleased"] = float64(m.rtm.HeapReleased)
+	m.Gauges["HeapSys"] = float64(m.rtm.HeapSys)
+	m.Gauges["LastGC"] = float64(m.rtm.LastGC)
+	m.Gauges["Lookups"] = float64(m.rtm.Lookups)
+	m.Gauges["MCacheInuse"] = float64(m.rtm.MCacheInuse)
+	m.Gauges["MCacheSys"] = float64(m.rtm.MCacheSys)
+	m.Gauges["MSpanSys"] = float64(m.rtm.MSpanSys)
+	m.Gauges["Mallocs"] = float64(m.rtm.Mallocs)
+	m.Gauges["NextGC"] = float64(m.rtm.NextGC)
+	m.Gauges["NumForcedGC"] = float64(m.rtm.NumForcedGC)
+	m.Gauges["NextGC"] = float64(m.rtm.NumGC)
+	m.Gauges["OtherSys"] = float64(m.rtm.OtherSys)
+	m.Gauges["PauseTotalNs"] = float64(m.rtm.PauseTotalNs)
+	m.Gauges["StackInuse"] = float64(m.rtm.StackInuse)
+	m.Gauges["StackSys"] = float64(m.rtm.StackSys)
+	m.Gauges["Sys"] = float64(m.rtm.Sys)
+	m.Gauges["TotalAlloc"] = float64(m.rtm.TotalAlloc)
+	m.Mutex.Unlock()
+}
+
+func NewMetrics() *Metrics {
+	var counters = map[string]int64{
+		"PollCount": 0,
+	}
+
+	var gauges = map[string]float64{
+		"Alloc":         0,
+		"BuckHashSys":   0,
+		"Frees":         0,
+		"GCCPUFraction": 0,
+		"GCSys":         0,
+		"HeapAlloc":     0,
+		"HeapIdle":      0,
+		"HeapInuse":     0,
+		"HeapObjects":   0,
+		"HeapReleased":  0,
+		"HeapSys":       0,
+		"LastGC":        0,
+		"Lookups":       0,
+		"MCacheInuse":   0,
+		"MCacheSys":     0,
+		"MSpanInuse":    0,
+		"MSpanSys":      0,
+		"Mallocs":       0,
+		"NextGC":        0,
+		"NumForcedGC":   0,
+		"NumGC":         0,
+		"OtherSys":      0,
+		"PauseTotalNs":  0,
+		"StackInuse":    0,
+		"StackSys":      0,
+		"Sys":           0,
+		"TotalAlloc":    0,
+		"RandomValue":   0,
+	}
+	return &Metrics{Counters: counters, Gauges: gauges, Mutex: sync.Mutex{}, rtm: runtime.MemStats{}}
+}


### PR DESCRIPTION
# Increment 1

Разработайте агент по сбору рантайм-метрик и их последующей отправке на сервер по протоколу HTTP. Разработку нужно вести с использованием [шаблона](https://github.com/yandex-praktikum/go-musthave-devops-tpl.git).

Агент должен собирать метрики двух типов:
- gauge, тип float64
- counter, тип int64

В качестве источника метрик используйте пакет runtime. Нужно собирать следующие метрики:
- Имя метрики: "Alloc", тип: gauge
- Имя метрики: "BuckHashSys", тип: gauge
- Имя метрики: "Frees", тип: gauge
- Имя метрики: "GCCPUFraction", тип: gauge
- Имя метрики: "GCSys", тип: gauge
- Имя метрики: "HeapAlloc", тип: gauge
- Имя метрики: "HeapIdle", тип: gauge
- Имя метрики: "HeapInuse", тип: gauge
- Имя метрики: "HeapObjects", тип: gauge
- Имя метрики: "HeapReleased", тип: gauge
- Имя метрики: "HeapSys", тип: gauge
- Имя метрики: "LastGC", тип: gauge
- Имя метрики: "Lookups", тип: gauge
- Имя метрики: "MCacheInuse", тип: gauge
- Имя метрики: "MCacheSys", тип: gauge
- Имя метрики: "MSpanInuse", тип: gauge
- Имя метрики: "MSpanSys", тип: gauge
- Имя метрики: "Mallocs", тип: gauge
- Имя метрики: "NextGC", тип: gauge
- Имя метрики: "NumForcedGC", тип: gauge
- Имя метрики: "NumGC", тип: gauge
- Имя метрики: "OtherSys", тип: gauge
- Имя метрики: "PauseTotalNs", тип: gauge
- Имя метрики: "StackInuse", тип: gauge
- Имя метрики: "StackSys", тип: gauge
- Имя метрики: "Sys", тип: gauge
- Имя метрики: "TotalAlloc", тип: gauge

К метрикам пакета runtime добавьте другие:
- Имя метрики: "PollCount", тип: counter — счётчик, увеличивающийся на 1 при каждом обновлении метрики из пакета runtime (на каждый pollInterval — см. ниже).
- Имя метрики: "RandomValue", тип: gauge — обновляемое рандомное значение.

По умолчанию приложение должно обновлять метрики из пакета runtime с заданной частотой: pollInterval — 2 секунды.

По умолчанию приложение должно отправлять метрики на сервер с заданной частотой: reportInterval — 10 секунд.

Метрики нужно отправлять по протоколу HTTP, методом POST:
- по умолчанию на адрес: 127.0.0.1, порт: 8080;
- в формате: http://<АДРЕС_СЕРВЕРА>/update/<ТИП_МЕТРИКИ>/<ИМЯ_МЕТРИКИ>/<ЗНАЧЕНИЕ_МЕТРИКИ>;
- Content-Type: text/plain