### PR TITLE
Sprint1 inc2

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
-	"log"
-	"net/http"
 	"sync"
 	"time"
 
 	"github.com/AndrewSukhobok95/yagometrics.git/internal/metrics"
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/poller"
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/reporter"
 )
 
 const (
@@ -17,58 +15,11 @@ const (
 	endpoint       = "127.0.0.1:8080"
 )
 
-func poll(m *metrics.Metrics) {
-	ticker := time.NewTicker(pollInterval)
-	for {
-		<-ticker.C
-		m.Update()
-		fmt.Println("poll")
-	}
-}
-
-func send(client *http.Client, endpoint string) {
-	request, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBufferString(""))
-	if err != nil {
-		log.Fatal(err)
-	}
-	request.Header.Add("Content-Type", "text/plain")
-	fmt.Println("do-start")
-	response, err := client.Do(request)
-	fmt.Println("do-end")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer response.Body.Close()
-}
-
-func report(m *metrics.Metrics) {
-	ticker := time.NewTicker(reportInterval)
-	client := &http.Client{}
-	fmt.Println("report-init")
-	for {
-		<-ticker.C
-		fmt.Println("report-tick")
-		m.Mutex.Lock()
-		counters := m.Counters
-		gauges := m.Gauges
-		m.Mutex.Unlock()
-		fmt.Println("report-start")
-		for k, v := range counters {
-			send(client, fmt.Sprintf("http://%s/update/%s/%s/%d", endpoint, "counter", k, v))
-		}
-		for k, v := range gauges {
-			send(client, fmt.Sprintf("http://%s/update/%s/%s/%f", endpoint, "gauge", k, v))
-		}
-		fmt.Println("report-end")
-	}
-}
-
 func main() {
 	var wg sync.WaitGroup
 	m := metrics.NewMetrics()
-	fmt.Println("start")
 	wg.Add(2)
-	go poll(m)
-	go report(m)
+	go poller.Poll(m, pollInterval)
+	go reporter.Report(m, endpoint, reportInterval)
 	wg.Wait()
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,3 +1,74 @@
 package main
 
-func main() {}
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/metrics"
+)
+
+const (
+	pollInterval   = time.Duration(2 * time.Second)
+	reportInterval = time.Duration(10 * time.Second)
+	endpoint       = "127.0.0.1:8080"
+)
+
+func poll(m *metrics.Metrics) {
+	ticker := time.NewTicker(pollInterval)
+	for {
+		<-ticker.C
+		m.Update()
+		fmt.Println("poll")
+	}
+}
+
+func send(client *http.Client, endpoint string) {
+	request, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBufferString(""))
+	if err != nil {
+		log.Fatal(err)
+	}
+	request.Header.Add("Content-Type", "text/plain")
+	fmt.Println("do-start")
+	response, err := client.Do(request)
+	fmt.Println("do-end")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer response.Body.Close()
+}
+
+func report(m *metrics.Metrics) {
+	ticker := time.NewTicker(reportInterval)
+	client := &http.Client{}
+	fmt.Println("report-init")
+	for {
+		<-ticker.C
+		fmt.Println("report-tick")
+		m.Mutex.Lock()
+		counters := m.Counters
+		gauges := m.Gauges
+		m.Mutex.Unlock()
+		fmt.Println("report-start")
+		for k, v := range counters {
+			send(client, fmt.Sprintf("http://%s/update/%s/%s/%d", endpoint, "counter", k, v))
+		}
+		for k, v := range gauges {
+			send(client, fmt.Sprintf("http://%s/update/%s/%s/%f", endpoint, "gauge", k, v))
+		}
+		fmt.Println("report-end")
+	}
+}
+
+func main() {
+	var wg sync.WaitGroup
+	m := metrics.NewMetrics()
+	fmt.Println("start")
+	wg.Add(2)
+	go poll(m)
+	go report(m)
+	wg.Wait()
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,52 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/handlers"
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/storage"
+)
+
+const (
+	endpoint = "127.0.0.1:8080"
+)
+
+func showMetrics(ms storage.Storage) {
+	for {
+		vg, err := ms.GetGaugeMetric("Alloc")
+		if err != nil {
+			fmt.Println("Alloc error")
+		} else {
+			fmt.Printf("Alloc %f \n", vg)
+		}
+		vc, err := ms.GetCounterMetric("PollCount")
+		if err != nil {
+			fmt.Println("PollCount error")
+		} else {
+			fmt.Printf("PollCount %d \n", vc)
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
+func main() {
+	memStorage := storage.NewMemStorage()
+	handler := handlers.NewMetricHandler(memStorage)
+	mux := http.NewServeMux()
+	mux.Handle("/update/", handler)
+
+	go showMetrics(memStorage)
+
+	fmt.Println("Start server")
+	server := &http.Server{
+		Addr:    endpoint,
+		Handler: mux,
+	}
+	err := server.ListenAndServe()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/AndrewSukhobok95/yagometrics.git
+
+go 1.19

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -23,27 +24,30 @@ func (mh MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	fields := ParseURL(r.URL.Path)
 	if len(fields) != 4 {
-		http.Error(w, "Broken address.", http.StatusBadRequest)
+		http.Error(w, "Broken address.", http.StatusNotFound)
 		return
 	}
 	metricType := fields[1]
 	metricName := fields[2]
 	metricValueString := fields[3]
-	if metricType == "gauge" {
+	switch {
+	case metricType == "gauge":
 		metricValue, err := strconv.ParseFloat(metricValueString, 64)
 		if err != nil {
 			http.Error(w, "Broken address.", http.StatusBadRequest)
 			return
 		}
 		mh.storage.InsertGaugeMetric(metricName, metricValue)
-	}
-	if metricType == "counter" {
+	case metricType == "counter":
 		metricValue, err := strconv.ParseInt(metricValueString, 10, 64)
 		if err != nil {
 			http.Error(w, "Broken address.", http.StatusBadRequest)
 			return
 		}
 		mh.storage.AddCounterMetric(metricName, metricValue)
+	default:
+		http.Error(w, fmt.Sprintf("%s metric type is not implemented.", metricName), http.StatusNotImplemented)
+		return
 	}
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,48 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/handlers"
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/storage"
+)
+
+func TestMetricHandler(t *testing.T) {
+	type want struct {
+		code        int
+		contentType string
+	}
+	tests := []struct {
+		name string
+		want want
+	}{
+		{
+			name: "positive test #1",
+			want: want{
+				code:        200,
+				contentType: "text/plain",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/update/gauge/Name1/111", bytes.NewBufferString(""))
+			w := httptest.NewRecorder()
+			memStorage := storage.NewMemStorage()
+			handler := handlers.NewMetricHandler(memStorage)
+			h := http.Handler(handler)
+			h.ServeHTTP(w, request)
+			res := w.Result()
+			if res.StatusCode != tt.want.code {
+				t.Errorf("Expected status code %d, got %d", tt.want.code, w.Code)
+			}
+			defer res.Body.Close()
+			if res.Header.Get("Content-Type") != tt.want.contentType {
+				t.Errorf("Expected Content-Type %s, got %s", tt.want.contentType, res.Header.Get("Content-Type"))
+			}
+		})
+	}
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -16,20 +16,46 @@ func TestMetricHandler(t *testing.T) {
 		contentType string
 	}
 	tests := []struct {
-		name string
-		want want
+		name    string
+		address string
+		want    want
 	}{
 		{
-			name: "positive test #1",
+			name:    "Positive test: Gauge metric",
+			address: "/update/gauge/Name1/111",
 			want: want{
 				code:        200,
 				contentType: "text/plain",
 			},
 		},
+		{
+			name:    "Positive test: Counter metric",
+			address: "/update/counter/Name1/111",
+			want: want{
+				code:        200,
+				contentType: "text/plain",
+			},
+		},
+		{
+			name:    "Negative test: Unkonwn metric",
+			address: "/update/unknown/Name1/111",
+			want: want{
+				code:        501,
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
+		{
+			name:    "Negative test: Empty value",
+			address: "/update/counter/Name1",
+			want: want{
+				code:        404,
+				contentType: "text/plain; charset=utf-8",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := httptest.NewRequest(http.MethodPost, "/update/gauge/Name1/111", bytes.NewBufferString(""))
+			request := httptest.NewRequest(http.MethodPost, tt.address, bytes.NewBufferString(""))
 			w := httptest.NewRecorder()
 			memStorage := storage.NewMemStorage()
 			handler := handlers.NewMetricHandler(memStorage)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"math/rand"
+	"runtime"
+	"sync"
+)
+
+type Metrics struct {
+	Counters map[string]int64
+	Gauges   map[string]float64
+	Mutex    sync.Mutex
+	rtm      runtime.MemStats
+}
+
+func (m *Metrics) Update() {
+	runtime.ReadMemStats(&m.rtm)
+	m.Mutex.Lock()
+	m.Counters["PollCount"] += 1
+	m.Gauges["RandomValue"] = rand.Float64()
+	m.Gauges["Alloc"] = float64(m.rtm.Alloc)
+	m.Gauges["BuckHashSys"] = float64(m.rtm.BuckHashSys)
+	m.Gauges["Frees"] = float64(m.rtm.Frees)
+	m.Gauges["GCCPUFraction"] = float64(m.rtm.GCCPUFraction)
+	m.Gauges["GCSys"] = float64(m.rtm.GCSys)
+	m.Gauges["HeapAlloc"] = float64(m.rtm.HeapAlloc)
+	m.Gauges["HeapIdle"] = float64(m.rtm.HeapIdle)
+	m.Gauges["HeapInuse"] = float64(m.rtm.HeapInuse)
+	m.Gauges["HeapObjects"] = float64(m.rtm.HeapObjects)
+	m.Gauges["HeapReleased"] = float64(m.rtm.HeapReleased)
+	m.Gauges["HeapSys"] = float64(m.rtm.HeapSys)
+	m.Gauges["LastGC"] = float64(m.rtm.LastGC)
+	m.Gauges["Lookups"] = float64(m.rtm.Lookups)
+	m.Gauges["MCacheInuse"] = float64(m.rtm.MCacheInuse)
+	m.Gauges["MCacheSys"] = float64(m.rtm.MCacheSys)
+	m.Gauges["MSpanSys"] = float64(m.rtm.MSpanSys)
+	m.Gauges["Mallocs"] = float64(m.rtm.Mallocs)
+	m.Gauges["NextGC"] = float64(m.rtm.NextGC)
+	m.Gauges["NumForcedGC"] = float64(m.rtm.NumForcedGC)
+	m.Gauges["NextGC"] = float64(m.rtm.NumGC)
+	m.Gauges["OtherSys"] = float64(m.rtm.OtherSys)
+	m.Gauges["PauseTotalNs"] = float64(m.rtm.PauseTotalNs)
+	m.Gauges["StackInuse"] = float64(m.rtm.StackInuse)
+	m.Gauges["StackSys"] = float64(m.rtm.StackSys)
+	m.Gauges["Sys"] = float64(m.rtm.Sys)
+	m.Gauges["TotalAlloc"] = float64(m.rtm.TotalAlloc)
+	m.Mutex.Unlock()
+}
+
+func NewMetrics() *Metrics {
+	var counters = map[string]int64{
+		"PollCount": 0,
+	}
+
+	var gauges = map[string]float64{
+		"Alloc":         0,
+		"BuckHashSys":   0,
+		"Frees":         0,
+		"GCCPUFraction": 0,
+		"GCSys":         0,
+		"HeapAlloc":     0,
+		"HeapIdle":      0,
+		"HeapInuse":     0,
+		"HeapObjects":   0,
+		"HeapReleased":  0,
+		"HeapSys":       0,
+		"LastGC":        0,
+		"Lookups":       0,
+		"MCacheInuse":   0,
+		"MCacheSys":     0,
+		"MSpanInuse":    0,
+		"MSpanSys":      0,
+		"Mallocs":       0,
+		"NextGC":        0,
+		"NumForcedGC":   0,
+		"NumGC":         0,
+		"OtherSys":      0,
+		"PauseTotalNs":  0,
+		"StackInuse":    0,
+		"StackSys":      0,
+		"Sys":           0,
+		"TotalAlloc":    0,
+		"RandomValue":   0,
+	}
+	return &Metrics{Counters: counters, Gauges: gauges, Mutex: sync.Mutex{}, rtm: runtime.MemStats{}}
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -1,0 +1,17 @@
+package poller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/metrics"
+)
+
+func Poll(m *metrics.Metrics, pollInterval time.Duration) {
+	ticker := time.NewTicker(pollInterval)
+	for {
+		<-ticker.C
+		m.Update()
+		fmt.Println("poll")
+	}
+}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -1,0 +1,48 @@
+package reporter
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/AndrewSukhobok95/yagometrics.git/internal/metrics"
+)
+
+func send(client *http.Client, endpoint string) {
+	request, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBufferString(""))
+	if err != nil {
+		log.Fatal(err)
+	}
+	request.Header.Add("Content-Type", "text/plain")
+	fmt.Println("do-start")
+	response, err := client.Do(request)
+	fmt.Println("do-end")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer response.Body.Close()
+}
+
+func Report(m *metrics.Metrics, endpoint string, reportInterval time.Duration) {
+	ticker := time.NewTicker(reportInterval)
+	client := &http.Client{}
+	fmt.Println("report-init")
+	for {
+		<-ticker.C
+		fmt.Println("report-tick")
+		m.Mutex.Lock()
+		counters := m.Counters
+		gauges := m.Gauges
+		m.Mutex.Unlock()
+		fmt.Println("report-start")
+		for k, v := range counters {
+			send(client, fmt.Sprintf("http://%s/update/%s/%s/%d", endpoint, "counter", k, v))
+		}
+		for k, v := range gauges {
+			send(client, fmt.Sprintf("http://%s/update/%s/%s/%f", endpoint, "gauge", k, v))
+		}
+		fmt.Println("report-end")
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Storage interface {
+	InsertGaugeMetric(name string, value float64)
+	InsertCounterMetric(name string, value int64)
+	AddCounterMetric(name string, value int64)
+	GetGaugeMetric(name string) (float64, error)
+	GetCounterMetric(name string) (int64, error)
+}
+
+type MemStorage struct {
+	counters map[string]int64
+	gauges   map[string]float64
+	mutex    sync.Mutex
+}
+
+func NewMemStorage() *MemStorage {
+	var ms MemStorage
+	ms.counters = make(map[string]int64)
+	ms.gauges = make(map[string]float64)
+	ms.mutex = sync.Mutex{}
+	return &ms
+}
+
+func (ms *MemStorage) InsertGaugeMetric(name string, value float64) {
+	ms.mutex.Lock()
+	ms.gauges[name] = value
+	ms.mutex.Unlock()
+}
+
+func (ms *MemStorage) InsertCounterMetric(name string, value int64) {
+	ms.mutex.Lock()
+	ms.counters[name] = value
+	ms.mutex.Unlock()
+}
+
+func (ms *MemStorage) AddCounterMetric(name string, value int64) {
+	ms.mutex.Lock()
+	ms.counters[name] += value
+	ms.mutex.Unlock()
+}
+
+func (ms *MemStorage) GetGaugeMetric(name string) (float64, error) {
+	ms.mutex.Lock()
+	value, ok := ms.gauges[name]
+	ms.mutex.Unlock()
+	if ok {
+		return value, nil
+	} else {
+		e := fmt.Errorf("The given metric name %s doesn't exist", name)
+		return 0, e
+	}
+}
+
+func (ms *MemStorage) GetCounterMetric(name string) (int64, error) {
+	ms.mutex.Lock()
+	value, ok := ms.counters[name]
+	ms.mutex.Unlock()
+	if ok {
+		return value, nil
+	} else {
+		e := fmt.Errorf("The given metric name %s doesn't exist", name)
+		return 0, e
+	}
+}


### PR DESCRIPTION
Разработайте сервер по сбору рантайм-метрик, который собирает репорты от агентов по протоколу HTTP.

Разработку следует продолжать в используемом репозитории (с предыдущими инкрементами), но сервер стоит размещать по своему пути: cmd/server/.

Сервер должен собирать и хранить произвольные метрики двух типов:
- gauge, тип float64, новое значение должно замещать предыдущее;
- counter, тип int64, новое значение должно добавляться к предыдущему (если оно ранее уже было известно серверу).

Метрики должны приниматься сервером по протоколу HTTP, методом POST:
- по умолчанию открывать порт 8080 на адресе 127.0.0.1;
- в формате http://<АДРЕС_СЕРВЕРА>/update/<ТИП_МЕТРИКИ>/<ИМЯ_МЕТРИКИ>/<ЗНАЧЕНИЕ_МЕТРИКИ>;
- Content-Type: text/plain;
- при успешном приёме возвращать статус: http.StatusOK.

Для хранения метрик создайте структуру MemStorage на стеке, опишите интерфейс для взаимодействия с этим хранилищем. Хендлеры HTTP-сервера должны взаимодействовать с экземпляром MemStorage посредством описанного интерфейса.

Покройте код агента и сервера юнит-тестами.